### PR TITLE
Do not make assertions about other buildpacks

### DIFF
--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -131,8 +131,6 @@ func testIntegration(t *testing.T, when spec.G, it spec.S) {
 			body, _, err := app.HTTPGet("/")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(body).To(ContainSubstring("Hello, World with pipenv!"))
-
-			Expect(app.BuildLogs()).To(MatchRegexp(`Installing Python \d+\.\d+\.\d+`))
 		})
 	})
 


### PR DESCRIPTION
This buildpack need not be dependent on a specific "Python" dependency.
It may use Python implementations like "CPython". Such an assertion is
outside the scope of this buildpack.